### PR TITLE
open file in 'wt' mode for dump

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -198,4 +198,4 @@ class pickledb(object):
     def _dumpdb(self, forced):
         '''Write/save the json dump into the file'''
         if forced:
-           simplejson.dump(self.db, open(self.loco, 'wb'))
+           simplejson.dump(self.db, open(self.loco, 'wt'))


### PR DESCRIPTION
I can add a `try/except` instruction for python2/3 compability.
And I added a issue.
