### PR TITLE
fix open file handle if pickledb.load fails

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -192,8 +192,19 @@ class pickledb(object):
         return True
 
     def _loaddb(self):
-        '''Load or reload the json info from the file'''
-        self.db = simplejson.load(open(self.loco, 'rb'))
+       '''Load or reload the json info from the file'''
+       fh = open(self.loco, 'rb')
+       try:
+			 self.db = json.load(fh)
+       except Exception, reason:
+          self.db={}
+			 #This assures that the file is not locked if json.load
+			 #fails e.g. due to corrupt file..
+			 #Clients of pickledb can then restore or delete the file.
+          fh.close()
+          raise Exception, reason
+		 #no reason to keep the file handle open.
+       fh.close()
 
     def _dumpdb(self, forced):
         '''Write/save the json dump into the file'''


### PR DESCRIPTION
Hi patx,

I had problems with my client when the json file was corrupt.
E.g. you simple add additional chars behind the closing curly bracket.
}sadfasdf

In this case pickledb raises an exception, but the file handle remains open.
I wanted to delete this file, but this was not possible due to open handle.
My proposal solves this issue.
Hope you like it...

Thank you,
 Thomas