### PR TITLE
Added syntax sugar

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -48,6 +48,18 @@ class pickledb(object):
         self.dthread = None
         self.set_sigterm_handler()
 
+    def __getitem__(self, item):
+        """ Syntax sugar for 'get' """
+        return self.get(item)
+
+    def __setitem__(self, key, value):
+        """ Sytax sugar for 'set' """
+        return self.set(key, value)
+
+    def __delitem__(self, key):
+        """ Sytax sugar for 'rem' """
+        return self.rem(key)
+
     def set_sigterm_handler(self):
         '''Assigns sigterm_handler for graceful shutdown during dump()'''
         def sigterm_handler():
@@ -79,7 +91,7 @@ class pickledb(object):
             self._dumpdb(self.fsave)
             return True
         else:
-            return self.key_string_error
+            raise self.key_string_error
 
     def get(self, key):
         '''Get the value of a key'''

--- a/tests.py
+++ b/tests.py
@@ -10,6 +10,20 @@ class TestClass(object):
         x = pickledb.load('x.db', False)
         assert x is not None
 
+    def test_sugar_get(self):
+        self.db.db["foo"] = "bar"
+        x = self.db["foo"]
+        assert x == "bar"
+
+    def test_sugar_set(self):
+        self.db["foo"] = "bar"
+        assert "bar" == self.db.db["foo"]
+
+    def test_sugar_rem(self):
+        self.db.db["foo"] = "bar"
+        del self.db["foo"]
+        assert "foo" not in self.db.db
+
     def test_set(self):
         self.db.set('key', 'value')
         x = self.db.get('key')


### PR DESCRIPTION
You can now do db["foo"] syntax as a short-hand for the `get`, `set`, and `rem` methods.
Also, tests were added for these features.