### PR TITLE
auto_dump parameter refactor proposal

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -20,7 +20,7 @@ a:hover { color: #008000; border-bottom: 1px solid #008000; }
 <div class="logo"><a href="index.html"><img src="logo.png" alt="pickleDB logo"></a></div>
 <div class="body">
 <h1>Current Commands</h1>
-<p><code><span class="c2">LOAD</span> <span class="c9">path</span> <span class="c9">dump</span></code> &rarr; Load a database from a file <small><em>(available since 0.1)</em></small></p>
+<p><code><span class="c2">LOAD</span> <span class="c9">path</span> <span class="c9">auto_dump</span></code> &rarr; Load a database from a path with auto_dump enabled or not <small><em>(available since 0.1)</em></small></p>
 <p><code><span class="c2">SET</span> <span class="c9">key</span> <span class="c9">value</span></code> &rarr; Set the value of a <em>str</em> key <small><em>(available since 0.1)</em></small></p>
 <p><code><span class="c2">GET</span> <span class="c9">key</span></code> &rarr; Get the value of a key <small><em>(available since 0.1)</em></small></p>
 <p><code><span class="c2">GETALL</span></code> &rarr; Return a list of all keys in database <small><em>(available since 0.4)</em></small></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@ with the BSD three-clause license.
 <code>
 <span class="c2">&gt;&gt;&gt;</span> <span class="c9">import</span> pickledb
 <br /><br />
-<span class="c2">&gt;&gt;&gt;</span> db = pickledb.load(<span class="c9">'example.db', False</span>)
+<span class="c2">&gt;&gt;&gt;</span> db = pickledb.load(<span class="c9">'example.db', auto_dump=False</span>)
 <br /><br />
 <span class="c2">&gt;&gt;&gt;</span> db.set(<span class="c9">'key', 'value'</span>)
 <br />

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pickledb
 
 # a work in progress
@@ -5,10 +6,10 @@ import pickledb
 
 class TestClass(object):
 
-    db = pickledb.load('tests.db', False)
+    db = pickledb.load('tests.db', auto_dump=False)
 
     def test_load(self):
-        x = pickledb.load('x.db', False)
+        x = pickledb.load('x.db', auto_dump=False)
         assert x is not None
 
     def test_sugar_get(self):
@@ -96,3 +97,11 @@ class TestClass(object):
         x = self.db.dexists('dict', 'not_key')
         assert x is False
         self.db.drem('dict')
+
+
+if __name__ == "__main__":
+    tests = TestClass()
+    test_methods = [method for method in dir(tests) if callable(getattr(tests, method)) if method.startswith('test_')]
+    for method in test_methods:
+            getattr(tests, method)()  # run method
+            print(".", end="")


### PR DESCRIPTION
Hi,
was taking a look at the code and the auto_dump capability was not very clear in the documentation.

I took the freedom to do a little refactor:
- Renamed `option` to `auto_dump`.
- Renamed the doc accordingly to `auto_dump`.
- Added some code to `tests.py` to make it runnable (I know it is a wip, but wanted to run it)

I added also a test to check that auto_dump was working after refactor, but as it messed with the filesystem (creating and removing the file) I removed it in the end.

Cheers,