### PR TITLE
Allow loading of currently empty files

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -99,7 +99,13 @@ class PickleDB(object):
         
     def _loaddb(self):
         '''Load or reload the json info from the file'''
-        self.db = json.load(open(self.loco, 'rt'))
+        try: 
+            self.db = json.load(open(self.loco, 'rt'))
+        except ValueError:
+            if os.stat(self.loco).st_size == 0  # Error raised because file is empty
+                self.db = {}
+            else:
+                raise  # File is not empty, avoid overwriting it
 
     def _autodumpdb(self):
         '''Write/save the json dump into the file if auto_dump is enabled'''

--- a/pickledb.py
+++ b/pickledb.py
@@ -96,13 +96,13 @@ class PickleDB(object):
         self.dthread.start()
         self.dthread.join()
         return True
-        
+
     def _loaddb(self):
         '''Load or reload the json info from the file'''
         try: 
             self.db = json.load(open(self.loco, 'rt'))
         except ValueError:
-            if os.stat(self.loco).st_size == 0  # Error raised because file is empty
+            if os.stat(self.loco).st_size == 0:  # Error raised because file is empty
                 self.db = {}
             else:
                 raise  # File is not empty, avoid overwriting it

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ Latest Release Notes (version: 0.9)
 from distutils.core import setup
 
 setup(name="pickleDB",
-    version="0.9.2",
+    version="0.9.3",
     description="A lightweight and simple database using json.",
     long_description=__doc__,
     author="Harrison Erd",


### PR DESCRIPTION
In a testing environment, `tempfile.mkstemp` generates temporary empty files, automatically cleaned after test execution.

This modification allow pickledb to use these files, without hacks like writing random JSON in the generated file.