### PR TITLE
Add some feature

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -26,6 +26,10 @@ class TestClass(object):
         del self.db["foo"]
         assert "foo" not in self.db.db
 
+    def test_sugar_exists(self):
+        self.db["foo"] = "bar"
+        assert "foo" in self.db
+
     def test_set(self):
         self.db.set('key', 'value')
         x = self.db.get('key')


### PR DESCRIPTION
Run _autodumpdb when python exit. Then it can auto dump the mutable variable when exit.
Add syntax surge for exists. Now can use `key in self.db` syntax.
Format the dumps string in file with indent 4.