### PR TITLE
Fix TypeError: sigterm_handler() takes 0 positional arguments but 2 were given

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -70,7 +70,7 @@ class PickleDB(object):
 
     def set_sigterm_handler(self):
         '''Assigns sigterm_handler for graceful shutdown during dump()'''
-        def sigterm_handler():
+        def sigterm_handler(*args, **kwargs):
             if self.dthread is not None:
                 self.dthread.join()
             sys.exit(0)


### PR DESCRIPTION
Fixes https://github.com/patx/pickledb/issues/68.

Tested with the simple test in the bug report.