### PR TITLE
Add file deletion option to deldb()

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -50,7 +50,7 @@ a:hover { color: #008000; border-bottom: 0px solid white; }
 <p><code><span class="c2">DREM</span> <span class="c9">name</span></code> &rarr; Remove a dict and all of its pairs <small><em>(available since 0.2.2)</em></small></p>
 <p><code><span class="c2">DPOP</span> <span class="c9">name</span> <span class="c9">key</span></code> &rarr; Remove one key-value in a dict <small><em>(available since 0.2.2)</em></small></p>
 <p><code><span class="c2">DMERGE</span> <span class="c9">name1</span> <span class="c9">name2</span> <span class="c9">name3</span></code> &rarr; Merge <code>name1</code> and <code>name2</code> into a new dict: <code>name3</code> <small><em>(available since 0.7.3)</em></small>
-<p><code><span class="c2">DELDB</span></code> &rarr; Delete everything from the database <small><em>(available since 0.2.1)</em></small></p>
+<p><code><span class="c2">DELDB</span> <span class="c9">andfile</span></code> &rarr; Delete everything from the database, set <code>andfile</code> to <code>True</code> to delete the database file too.<small><em>(available since 0.2.1)</em></small></p>
 <p><code><span class="c2">DUMP</span></code> &rarr; Save the database from memory to a file specified in <code>LOAD</code> <small><em>(available since 0.3)</em></small></p>
 <h1>Suggestions</h1>
 <p>If you would like to suggest a command, you can create an <a href="http://github.com/patx/pickledb/issues">issue on GitHub</a>.</p>

--- a/pickledb.py
+++ b/pickledb.py
@@ -47,13 +47,13 @@ def load(location, auto_dump, sig=True):
 
 class PickleDB(object):
 
-    key_string_error = TypeError('Key/name must be a string!')
-
+    key_string_error = TypeError('Key/name must be a string!') 
     def __init__(self, location, auto_dump, sig):
         '''Creates a database object and loads the data from the location path.
         If the file does not exist it will be created on the first update.
         '''
         self.load(location, auto_dump)
+        self.__location__ = location
         self.dthread = None
         if sig:
             self.set_sigterm_handler()
@@ -63,11 +63,11 @@ class PickleDB(object):
         return self.get(item)
 
     def __setitem__(self, key, value):
-        '''Sytax sugar for set()'''
+        '''Syntax sugar for set()'''
         return self.set(key, value)
 
     def __delitem__(self, key):
-        '''Sytax sugar for rem()'''
+        '''Syntax sugar for rem()'''
         return self.rem(key)
 
     def set_sigterm_handler(self):
@@ -290,9 +290,11 @@ class PickleDB(object):
         self._autodumpdb()
         return True
 
-    def deldb(self):
-        '''Delete everything from the database'''
+    def deldb(self, andfile = False):
+        '''Delete everything from the database, optionally delete the database file'''
         self.db = {}
         self._autodumpdb()
+        if andfile:
+            os.remove(self.__location__)
         return True
 

--- a/tests.py
+++ b/tests.py
@@ -108,6 +108,14 @@ class TestClass(object):
         assert x is False
         self.db.drem('dict')
 
+    def test_location(self):
+        assert self.db.__location__ == 'tests.db'
+        self.db.dump()
+        self.db.deldb()
+        from pickledb import os
+        assert os.path.exists(self.db.__location__)
+        self.db.deldb(True)
+        assert not os.path.exists(self.db.__location__)
 
 if __name__ == "__main__":
     tests = TestClass()


### PR DESCRIPTION
### Additions
`___location__ : str` a string in the `PickleDB` class that holds the database path as entered
### Modified
`deldb(self, andfile = False)` the deletion function now includes an option to delete the database file.

This implementation is non breaking. Existing calls to `deldb()` will not delete the file unless `deldb(True)` is called (which is invalid in older implementations, so there isn't a risk to production code.)

### Creature comforts
Additional unit tests for new functionality, fixed docstring typos, updated relevant docstrings and HTML documentation.
`pytest tests.py` reports 100% ✅