### PR TITLE
fix: [pickledb.py] try-except issue #91

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -129,10 +129,7 @@ class PickleDB(object):
 
     def get(self, key):
         '''Get the value of a key'''
-        try:
-            return self.db[key]
-        except KeyError:
-            return False
+        return self.db.get(key, False)
 
     def getall(self):
         '''Return a list of all keys in db'''


### PR DESCRIPTION
fixed the issue #91 by changing this:
```
try:
    return self.db[key]
except KeyError:
    return False
```
into this:
```
return self.db.keys()
```