### PR TITLE
Fix dump with multiple threads

### DIFF
--- a/pickledb.py
+++ b/pickledb.py
@@ -100,7 +100,8 @@ class PickleDB(object):
         '''Force dump memory db to file'''
         self.dthread = Thread(target=self._dump)
         self.dthread.start()
-        self.dthread.join()
+        if self.dthread.is_alive():
+            self.dthread.join()
         return True
 
     def _loaddb(self):


### PR DESCRIPTION
This is my code:

`import time
import threading

def run():
    while True:
        count = db.get("count")
        if not count:
            db.set("count", 1)
        db.set("count", count + 1)
        time.sleep(1)

threading.Thread(target=run, daemon=True).start()
threading.Thread(target=run, daemon=True).start()

while True:
    time.sleep(1)`

When I use this library with multiple threads I got an error like below:

`Exception in thread Thread-1 (run):
Traceback (most recent call last):
  File "C:\Program Files\Python311\Lib\threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "C:\Program Files\Python311\Lib\threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "D:\USER\controlhub\main.py", line 25, in run
    db.set("count", count + 1)
  File "D:\USER\controlhub\pickledb.py", line 129, in set
    self._autodumpdb()
  File "D:\USER\controlhub\pickledb.py", line 123, in _autodumpdb
    self.dump()
  File "D:\USER\controlhub\pickledb.py", line 107, in dump
    self.dthread.join()
  File "C:\Program Files\Python311\Lib\threading.py", line 1107, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started`

And I fixed them by adding a line of code in the `dump` function